### PR TITLE
Fix error when `options.reportOnly` is set.

### DIFF
--- a/lib/middleware/csp.js
+++ b/lib/middleware/csp.js
@@ -107,7 +107,7 @@ module.exports = function csp(options) {
 
           policy['default-src'] = policy['default-src'] || ['*'];
 
-          Object.keys(options).forEach(function (key) {
+          Object.keys(policy).forEach(function (key) {
 
             var value = options[key];
 


### PR DESCRIPTION
Only happens in Firefox >=4 && Firefox <= 23
