### PR TITLE
 Updated HSTS with preload flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,18 @@ app.use(helmet.hsts());
 To adjust other values for `maxAge` and to include subdomains:
 
 ```javascript
-app.use(helmet.hsts(1234567, true));
+app.use(helmet.hsts(1234567, true, false));
 ```
 
 Note that the max age is in _seconds_, not milliseconds (as is typical in JavaScript).
+
+To enable the `preload` flag in the HSTS header with a custom `maxAge` and `includeSubdomains` set as follows:
+
+```javascript
+app.use(helmet.hsts(1234567, true, true));
+```
+
+Note the `preload` flag is required for domain includision in Chrome's HSTS (preload)[https://hstspreload.appspot.com/] list. This is a list of sites that are hardcoded into Chrome as being HTTPS only.
 
 X-Frame-Options
 ---------------

--- a/lib/middleware/hsts.js
+++ b/lib/middleware/hsts.js
@@ -5,11 +5,13 @@
  *
  * http://tools.ietf.org/html/rfc6797
  */
-module.exports = function (maxAge, includeSubdomains) {
+module.exports = function (maxAge, includeSubdomains, preload) {
   if (!maxAge) maxAge = '15768000'; // Approximately 6 months
   var header = "max-age=" + maxAge;
 
   if (includeSubdomains) header += '; includeSubdomains';
+
+  if (preload) header += '; preload';
 
   return function *hsts(next)  {
     if (this.secure || this.get('x-forwarded-proto') === 'https') {

--- a/test/hsts.js
+++ b/test/hsts.js
@@ -24,8 +24,8 @@ describe('hsts', function() {
       .expect('Strict-Transport-Security', 'max-age=15768000', done);
   });
 
-  it('sets header properly with args', function(done) {
-    app.use(helmet.hsts('1234', true));
+  it('sets header properly with includeSubdomains', function(done) {
+    app.use(helmet.hsts('1234', true, false));
     app.use(function *() {
       this.body = 'Hello world!';
     });
@@ -34,6 +34,18 @@ describe('hsts', function() {
       .get('/')
       .set('x-forwarded-proto', 'https')
       .expect('Strict-Transport-Security', 'max-age=1234; includeSubdomains', done);
+  });
+
+  it('sets header properly with all args enabled', function(done) {
+    app.use(helmet.hsts('1234', true, true));
+    app.use(function *() {
+      this.body = 'Hello world!';
+    });
+
+    request(app.listen())
+      .get('/')
+      .set('x-forwarded-proto', 'https')
+      .expect('Strict-Transport-Security', 'max-age=1234; includeSubdomains; preload', done);
   });
 
 });


### PR DESCRIPTION
Hey, I've updated the HSTS implementation to support the preload flag. This flag is required for domain inclusion in Chrome's HSTS preload list. The changes include new feature support, new test case, and updated README. Also, this feature is currently already in helmet.js [1].

More information regarding preload is available below.
https://hstspreload.appspot.com/

[1] https://github.com/helmetjs/hsts/search?utf8=%E2%9C%93&q=preload