### PR TITLE
 Updated defaults() to disable HPKP.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ fs.readdirSync(__dirname + '/middleware').forEach(function(filename) {
 module.exports.defaults = function(overrides) {
   var modules = [];
 
-  overrides = overrides || { csp: false };
+  overrides = overrides || { csp: false, hpkp: false};
   overrides.defaults = false;
 
   for (var name in module.exports) {


### PR DESCRIPTION
Updated `helmet.defaults()` to disable HPKP. Otherwise, certificate pins must be configured.

At the moment, `helmet.defaults()` triggers the following:
`throw new Error('A map of `pins` must be defined');`