### PR TITLE
Bump helmet to ^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">= 4.0.0"
   },
   "dependencies": {
-    "helmet": "^0.14.0"
+    "helmet": "^1.0.1"
   },
   "devDependencies": {
     "koa": ">= 2.0.0-alpha.3",

--- a/test/integration.js
+++ b/test/integration.js
@@ -75,7 +75,7 @@ describe('integration', function() {
         .expect('X-Content-Type-Options', 'nosniff')
 
         // publicKeyPins
-        .expect('Public-Key-Pins-Report-Only', 'pin-sha256="AbCdEf123="; pin-sha256="ZyXwVu456="; max-age=1; includeSubdomains; report-uri="http://example.com"')
+        .expect('Public-Key-Pins', 'pin-sha256="AbCdEf123="; pin-sha256="ZyXwVu456="; max-age=1; includeSubdomains; report-uri="http://example.com"')
         .expect(201, 'Hello world!', done);
     });
   });


### PR DESCRIPTION
This is a backward-incompatible change, but updating helmet is especially useful to be able to use nonces in CSP, as documented [here](https://github.com/helmetjs/csp#generating-nonces).