### PR TITLE
Set Koa dependency as "next"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "helmet": "^2.1.1"
   },
   "devDependencies": {
-    "koa": ">= 2.0.0",
+    "koa": "next",
     "mocha": "^2.5.3",
     "supertest": "^1.2.0",
     "underscore": "^1.8.3"
   },
   "peerDependencies": {
-    "koa": ">= 2.0.0"
+    "koa": "next"
   },
   "scripts": {
     "test": "mocha test"


### PR DESCRIPTION
By declaring `"koa": "next"` as dependency on `package.json`, it's ensured that latest `-alpha.x` release is fetched from **npm**. Otherwise, you miss out on those and always end up installing https://github.com/koajs/koa/commit/3595ef58b96f1e5f2ff83384bfa0409a30797e7a instead, which does not seem to be the intention of `^2.0.0` (or `>= 2.0.0`).

Moreover, projects using `koa-helmet` will receive:

``` sh
npm WARN koa-helmet@2.0.0 requires a peer of koa@^2.0.0 but none was installed.
```

If not using version `2.0.0` specifically.
