### PR TITLE
Issue - Helmet messes with response causing later middleware to fail

### DIFF
--- a/lib/koa-helmet.js
+++ b/lib/koa-helmet.js
@@ -8,7 +8,9 @@ const koaHelmet = function () {
 
   return (ctx, next) => {
     ctx.req.secure = ctx.request.secure
-    return helmetPromise(ctx.req, ctx.res).then(next)
+    return next().then(() => {
+      helmetPromise(ctx.req, ctx.res)
+    })
   }
 }
 


### PR DESCRIPTION
This is a change so that helmet runs after the rest of the middleware stack has run and then adds the response headers. This is because I was getting an issue where it was messing with the response in a way another library was not expecting and thought that as this only adds response headers it shouldn't do any work until the rest of the app has done it's work.

My middleware stack now looks like:
```
app.use(logger())
  .use(helmet())
  .use(error())
  // etc
  .user(router().routes)
```