### PR TITLE
fix koa DEBUG name not being set

### DIFF
--- a/lib/koa-helmet.js
+++ b/lib/koa-helmet.js
@@ -6,10 +6,12 @@ const promisify = require('./promisify')
 const koaHelmet = function () {
   const helmetPromise = promisify(helmet.apply(null, arguments))
 
-  return (ctx, next) => {
+  const middleware = (ctx, next) => {
     ctx.req.secure = ctx.request.secure
     return helmetPromise(ctx.req, ctx.res).then(next)
   }
+  middleware._name = 'helmet'
+  return middleware
 }
 
 Object.keys(helmet).forEach(function (helmetMethod) {


### PR DESCRIPTION
Without this koa's [debug mode](https://github.com/koajs/koa/blob/master/docs/guide.md#debugging-koa) returns `-` for the middleware name.

For example with my application before and after.

```
  koa:application use compress +0ms
  koa:application use responseTime +2ms
  koa:application use logger +0ms
  koa:application use conditional +0ms
  koa:application use etag +1ms
  koa:application use - +2ms
```

```
  koa:application use compress +0ms
  koa:application use responseTime +2ms
  koa:application use logger +1ms
  koa:application use conditional +1ms
  koa:application use etag +0ms
  koa:application use helmet +3ms
```