### PR TITLE
feat: re-export middleware functions' own assigned properties

### DIFF
--- a/lib/koa-helmet.js
+++ b/lib/koa-helmet.js
@@ -16,14 +16,16 @@ const koaHelmet = function () {
 
 Object.keys(helmet).forEach(function (helmetMethod) {
   koaHelmet[helmetMethod] = function () {
-    const method = helmet[helmetMethod];
-    const methodPromise = promisify(method.apply(null, arguments));
+    const methodPromise = promisify(helmet[helmetMethod].apply(null, arguments));
 
     return (ctx, next) => {
       ctx.req.secure = ctx.request.secure;
       return methodPromise(ctx.req, ctx.res).then(next);
     };
   };
+  Object.keys(helmet[helmetMethod]).forEach((methodExports) => {
+    koaHelmet[helmetMethod][methodExports] = helmet[helmetMethod][methodExports];
+  });
 });
 
 module.exports = koaHelmet;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
-    "helmet": "^4.1.1"
+    "helmet": "^4.4.1"
   },
   "devDependencies": {
     "ava": "^3.13.0",

--- a/test/koa-helmet.spec.js
+++ b/test/koa-helmet.spec.js
@@ -115,3 +115,8 @@ test('it sets individual headers properly', t => {
       .catch(err => t.fail(err))
   );
 });
+
+test('it reexports middleware exports', t => {
+  t.true('getDefaultDirectives' in helmet.contentSecurityPolicy);
+  t.true('dangerouslyDisableDefaultSrc' in helmet.contentSecurityPolicy);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,10 +1650,10 @@ hasha@^5.0.0:
     is-stream "^1.1.0"
     type-fest "^0.3.0"
 
-helmet@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-4.1.1.tgz#751f0e273d809ace9c172073e0003bed27d27a4a"
-  integrity sha512-Avg4XxSBrehD94mkRwEljnO+6RZx7AGfk8Wa6K1nxaU+hbXlFOhlOIMgPfFqOYQB/dBCsTpootTGuiOG+CHiQA==
+helmet@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-4.4.1.tgz#a17e1444d81d7a83ddc6e6f9bc6e2055b994efe7"
+  integrity sha512-G8tp0wUMI7i8wkMk2xLcEvESg5PiCitFMYgGRc/PwULB0RVhTP5GFdxOwvJwp9XVha8CuS8mnhmE8I/8dx/pbw==
 
 hosted-git-info@^2.1.4:
   version "2.8.4"


### PR DESCRIPTION
This PR makes sure the current and any future [individual middleware own property exports](https://github.com/helmetjs/helmet/blob/v4.4.1/middlewares/content-security-policy/index.ts#L228-L229) are also part of the koa-helmet API.

Closes #63