### PR TITLE
useDefaults type definition

### DIFF
--- a/koa-helmet.d.ts
+++ b/koa-helmet.d.ts
@@ -36,6 +36,7 @@ declare namespace koaHelmet {
 
     interface KoaHelmetContentSecurityPolicyConfiguration {
         reportOnly?: boolean;
+        useDefaults?: boolean;
         directives?: KoaHelmetContentSecurityPolicyDirectives;
     }
 


### PR DESCRIPTION
This PR adds support for `useDefaults`: https://github.com/helmetjs/helmet

I raised a PR to get this added to the type definition in Definitely Typed yesterday: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/feat/koa-helmet/types/koa-helmet/index.d.ts#L40

By the looks of it, this repo now ships with it's own types and it might be a good idea to delist from Definitely Typed.  I was having a mysterious morning until I realised there were two type definition files in my world!

cc @nsimmons and @dolezel