### PR TITLE
Upgrade helmet version to 6.0.1, fix types definitions

### DIFF
--- a/koa-helmet.d.ts
+++ b/koa-helmet.d.ts
@@ -28,10 +28,17 @@ declare namespace koaHelmet {
         mediaSrc?: KoaHelmetCspDirectiveValue[];
         objectSrc?: KoaHelmetCspDirectiveValue[];
         pluginTypes?: KoaHelmetCspDirectiveValue[];
+        prefetchSrc?: KoaHelmetCspDirectiveValue[];
+        reportTo?: string;
         reportUri?: string;
         sandbox?: KoaHelmetCspDirectiveValue[];
         scriptSrc?: KoaHelmetCspDirectiveValue[];
+        scriptSrcAttr?: KoahelmetCspDirectiveValue[];
+        scriptSrcElem?: KoaHelmetCspDirectiveValue[];
         styleSrc?: KoaHelmetCspDirectiveValue[];
+        styleSrcAttr?: KoaHelmetCspDirectiveValue[];
+        styleSrcElem?: KoaHelmetCspDirectiveValue[];
+        workerSrc?: KoaHelmetCspDirectiveValue[];
     }
 
     interface KoaHelmetContentSecurityPolicyConfiguration {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "koa-helmet",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "6.0.0",
+      "name": "koa-helmet",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
-        "helmet": "^4.4.1"
+        "helmet": "^6.0.1"
       },
       "devDependencies": {
         "ava": "^3.13.0",
@@ -176,9 +177,13 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -196,13 +201,17 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.13.10",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
@@ -1984,29 +1993,6 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "node_modules/eslint/node_modules/@babel/highlight": {
-      "version": "7.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "2.0.0",
       "dev": true,
@@ -2555,10 +2541,11 @@
       }
     },
     "node_modules/helmet": {
-      "version": "4.4.1",
-      "license": "MIT",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
+      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -5434,7 +5421,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -5451,10 +5440,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.13.10",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -6582,26 +6573,6 @@
             "@babel/highlight": "^7.10.4"
           }
         },
-        "@babel/highlight": {
-          "version": "7.5.0",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
         "eslint-visitor-keys": {
           "version": "2.0.0",
           "dev": true
@@ -6988,7 +6959,9 @@
       }
     },
     "helmet": {
-      "version": "4.4.1"
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
+      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw=="
     },
     "hosted-git-info": {
       "version": "2.8.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/venables/koa-helmet"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 14.0.0"
   },
   "dependencies": {
     "helmet": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Matt Venables <mattvenables@gmail.com>",
   "description": "Security header middleware collection for koa",
   "license": "MIT",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "main": "lib/koa-helmet.js",
   "typings": "./koa-helmet.d.ts",
   "scripts": {
@@ -27,7 +27,7 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
-    "helmet": "^4.4.1"
+    "helmet": "^6.0.1"
   },
   "devDependencies": {
     "ava": "^3.13.0",

--- a/test/koa-helmet.spec.js
+++ b/test/koa-helmet.spec.js
@@ -22,9 +22,6 @@ test('it works with the default helmet call', t => {
       // dnsPrefetchControl
       .expect('X-DNS-Prefetch-Control', 'off')
 
-      // expectCt
-      .expect('Expect-CT', 'max-age=0')
-
       // frameguard
       .expect('X-Frame-Options', 'SAMEORIGIN')
 
@@ -107,9 +104,6 @@ test('it sets individual headers properly', t => {
 
       // permittedCrossDomainPolicies
       .expect('X-Permitted-Cross-Domain-Policies', 'none')
-
-      // expectCt
-      .expect('Expect-CT', 'max-age=0')
 
       .then(() => t.pass())
       .catch(err => t.fail(err))

--- a/test/koa-helmet.spec.js
+++ b/test/koa-helmet.spec.js
@@ -17,7 +17,7 @@ test('it works with the default helmet call', t => {
       .get('/')
 
       // contentSecurityPolicy
-      .expect('Content-Security-Policy', 'default-src \'self\';base-uri \'self\';block-all-mixed-content;font-src \'self\' https: data:;frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests')
+      .expect('Content-Security-Policy', 'default-src \'self\';base-uri \'self\';font-src \'self\' https: data:;form-action \'self\';frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests')
 
       // dnsPrefetchControl
       .expect('X-DNS-Prefetch-Control', 'off')
@@ -45,7 +45,9 @@ test('it works with the default helmet call', t => {
 
       .expect(200)
       .then(() => t.pass())
-      .catch(err => t.fail(err))
+      .catch((err) => {
+        t.fail(err);}
+      )
   );
 });
 
@@ -79,7 +81,7 @@ test('it sets individual headers properly', t => {
       .get('/')
 
       // contentSecurityPolicy
-      .expect('Content-Security-Policy', 'default-src \'self\';base-uri \'self\';block-all-mixed-content;font-src \'self\' https: data:;frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests')
+      .expect('Content-Security-Policy', 'default-src \'self\';base-uri \'self\';font-src \'self\' https: data:;form-action \'self\';frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests')
 
       // dnsPrefetchControl
       .expect('X-DNS-Prefetch-Control', 'off')


### PR DESCRIPTION
## Changelog

- update type definitions for modern helmet (missing directives for CSP)
- remove expect-ct from default inclusion on test cases (follows helmet's deprecation of Expect-CT)
- update tests for default CSP setup based on newer helmet definitions (no deprecated `blocked-mixed-content` and `form-action` makes the default now)
- bump helmet version and relock `package.json`
- inherit engine version from upstream helmet dep
