### PR TITLE
feat(issue#85): add support for cross-origin headers

### DIFF
--- a/koa-helmet.d.ts
+++ b/koa-helmet.d.ts
@@ -8,7 +8,7 @@
 import helmet = require('helmet');
 import { Middleware, Context } from 'koa';
 
-type HelmetOptions = Required<Parameters<typeof helmet>>[0];
+type HelmetOptions = helmet.HelmetOptions;
 
 declare namespace koaHelmet {
     type KoaHelmetContentSecurityPolicyDirectiveFunction = (ctx: Context) => string;
@@ -50,6 +50,9 @@ declare namespace koaHelmet {
     interface KoaHelmet {
         (options?: HelmetOptions): Middleware;
         contentSecurityPolicy(options?: KoaHelmetContentSecurityPolicyConfiguration): Middleware;
+        crossOriginEmbedderPolicy(options?: HelmetOptions['crossOriginEmbedderPolicy']): Middleware;
+        crossOriginOpenerPolicy(options?: HelmetOptions['crossOriginOpenerPolicy']): Middleware;
+        crossOriginResourcePolicy(options?: HelmetOptions['crossOriginResourcePolicy']): Middleware;
         dnsPrefetchControl(options?: HelmetOptions['dnsPrefetchControl']): Middleware;
         expectCt(options?: HelmetOptions['expectCt']): Middleware;
         frameguard(options?: HelmetOptions['frameguard']): Middleware;

--- a/test/koa-helmet.spec.js
+++ b/test/koa-helmet.spec.js
@@ -19,6 +19,15 @@ test('it works with the default helmet call', t => {
       // contentSecurityPolicy
       .expect('Content-Security-Policy', 'default-src \'self\';base-uri \'self\';font-src \'self\' https: data:;form-action \'self\';frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests')
 
+      // crossOriginEmbedderPolicy
+      .expect('Cross-Origin-Embedder-Policy', 'require-corp')
+
+      // crossOriginOpenerPolicy
+      .expect('Cross-Origin-Opener-Policy', 'same-origin')
+
+      // crossOriginResourcePolicy
+      .expect('Cross-Origin-Resource-Policy', 'same-origin')
+      
       // dnsPrefetchControl
       .expect('X-DNS-Prefetch-Control', 'off')
 
@@ -58,6 +67,9 @@ test('it sets individual headers properly', t => {
       force: true
     })
   );
+  app.use(helmet.crossOriginEmbedderPolicy());
+  app.use(helmet.crossOriginOpenerPolicy());
+  app.use(helmet.crossOriginResourcePolicy());
   app.use(helmet.contentSecurityPolicy());
   app.use(
     helmet.dnsPrefetchControl({
@@ -83,6 +95,15 @@ test('it sets individual headers properly', t => {
       // contentSecurityPolicy
       .expect('Content-Security-Policy', 'default-src \'self\';base-uri \'self\';font-src \'self\' https: data:;form-action \'self\';frame-ancestors \'self\';img-src \'self\' data:;object-src \'none\';script-src \'self\';script-src-attr \'none\';style-src \'self\' https: \'unsafe-inline\';upgrade-insecure-requests')
 
+      // crossOriginEmbedderPolicy
+      .expect('Cross-Origin-Embedder-Policy', 'require-corp')
+
+      // crossOriginOpenerPolicy
+      .expect('Cross-Origin-Opener-Policy', 'same-origin')
+
+      // crossOriginResourcePolicy
+      .expect('Cross-Origin-Resource-Policy', 'same-origin')
+      
       // dnsPrefetchControl
       .expect('X-DNS-Prefetch-Control', 'off')
 

--- a/test/koa-helmet.spec.js
+++ b/test/koa-helmet.spec.js
@@ -67,10 +67,10 @@ test('it sets individual headers properly', t => {
       force: true
     })
   );
+  app.use(helmet.contentSecurityPolicy());
   app.use(helmet.crossOriginEmbedderPolicy());
   app.use(helmet.crossOriginOpenerPolicy());
   app.use(helmet.crossOriginResourcePolicy());
-  app.use(helmet.contentSecurityPolicy());
   app.use(
     helmet.dnsPrefetchControl({
       allow: false,
@@ -103,7 +103,7 @@ test('it sets individual headers properly', t => {
 
       // crossOriginResourcePolicy
       .expect('Cross-Origin-Resource-Policy', 'same-origin')
-      
+
       // dnsPrefetchControl
       .expect('X-DNS-Prefetch-Control', 'off')
 


### PR DESCRIPTION
This PR adds support for the `Cross-Origin-*` headers, raised by issue #85 