### PR TITLE
Test & fix with helmet v7 and set as a peer dependency on `^6||^7`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "koa-helmet",
       "version": "7.0.2",
       "license": "MIT",
-      "dependencies": {
-        "helmet": "^7.1.0"
-      },
       "devDependencies": {
         "ava": "^3.13.0",
         "coveralls": "^3.1.0",
@@ -22,6 +19,9 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      },
+      "peerDependencies": {
+        "helmet": "^6 || ^7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2544,6 +2544,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
       "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -6961,7 +6962,8 @@
     "helmet": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
-      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg=="
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "peer": true
     },
     "hosted-git-info": {
       "version": "2.8.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
-        "helmet": "^6.0.1"
+        "helmet": "^7.1.0"
       },
       "devDependencies": {
         "ava": "^3.13.0",
@@ -2541,11 +2541,11 @@
       }
     },
     "node_modules/helmet": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
-      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -6959,9 +6959,9 @@
       }
     },
     "helmet": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
-      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg=="
     },
     "hosted-git-info": {
       "version": "2.8.8",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "engines": {
     "node": ">= 14.0.0"
   },
-  "dependencies": {
-    "helmet": "~7"
+  "peerDependencies": {
+    "helmet": "^6 || ^7"
   },
   "devDependencies": {
     "ava": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">= 14.0.0"
   },
   "dependencies": {
-    "helmet": "^6.0.1"
+    "helmet": "~7"
   },
   "devDependencies": {
     "ava": "^3.13.0",

--- a/test/koa-helmet.spec.js
+++ b/test/koa-helmet.spec.js
@@ -70,7 +70,6 @@ test('it sets individual headers properly', t => {
   app.use(helmet.frameguard('deny'));
   app.use(helmet.noSniff());
   app.use(helmet.permittedCrossDomainPolicies());
-  app.use(helmet.expectCt());
 
   app.use(ctx => {
     ctx.body = 'Hello world!';


### PR DESCRIPTION
In order to pull in the most recent version of helmet, test updating to Helmet latest (v7).

In order to allow further updates to Helmet in future set as a peer dependency.
Set peer dependency for ^7 for current and tested Helmet v7.
Set to peer dependency `|| ^6` to back-compatibly support Helmet v6 in case that is needed.

The fix for Helmet v7 required removal of `helmet.expectCt()`

From https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md:

    Expect-CT is no longer part of Helmet. If you still need it, you can use the expect-ct package.
    https://github.com/helmetjs/helmet/issues/378
