### PR TITLE
fix type declarations

### DIFF
--- a/koa-helmet.d.ts
+++ b/koa-helmet.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-helmet 6.0
+// Type definitions for koa-helmet 7.0
 // Project: https://github.com/venables/koa-helmet#readme
 // Definitions by: Nick Simmons <https://github.com/nsimmons>
 //                 Jan Dolezel <https://github.com/dolezel>
@@ -11,7 +11,7 @@ import { Middleware, Context } from 'koa';
 type HelmetOptions = Required<Parameters<typeof helmet>>[0];
 
 declare namespace koaHelmet {
-    type KoaHelmetContentSecurityPolicyDirectiveFunction = (ctx: Context) => string;
+    type KoaHelmetContentSecurityPolicyDirectiveFunction = (req?: Context["req"], res?: Context["res"]) => string;
 
     type KoaHelmetCspDirectiveValue = string | KoaHelmetContentSecurityPolicyDirectiveFunction;
 


### PR DESCRIPTION
The optional predicate function for a directive rule isn't being called with a single `koa.Context`, it's being called with a `(ctx.req, ctx.res)`, which are the `http.IncomingMessage` and `http.ServerResponse` according to `helmet`'s own type definitions.

Closes #90 