### PR TITLE
Add missing CSP directive upgradeInsecureRequests

### DIFF
--- a/koa-helmet.d.ts
+++ b/koa-helmet.d.ts
@@ -43,6 +43,7 @@ declare namespace koaHelmet {
     styleSrc?: KoaHelmetCspDirectiveValue[];
     styleSrcAttr?: KoaHelmetCspDirectiveValue[];
     styleSrcElem?: KoaHelmetCspDirectiveValue[];
+    upgradeInsecureRequests: never[];
     workerSrc?: KoaHelmetCspDirectiveValue[];
   }
 


### PR DESCRIPTION
After the latest upgrade I noticed the `upgradeInsecureRequests` directive was missing from the CSP types.