### PR TITLE
Fix typescript issues after latest release 7.1.0

### DIFF
--- a/koa-helmet.d.ts
+++ b/koa-helmet.d.ts
@@ -2,86 +2,19 @@
 // Project: https://github.com/venables/koa-helmet#readme
 // Definitions by: Nick Simmons <https://github.com/nsimmons>
 //                 Jan Dolezel <https://github.com/dolezel>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+//                 Julien Wajsberg <https://github.com/julienw>
 // TypeScript Version: 2.3
 
-import helmet from "helmet";
-import { Middleware, Context } from "koa";
+import type { default as helmet, HelmetOptions } from "helmet";
+import { Middleware } from "koa";
 
-type HelmetOptions = helmet.HelmetOptions;
+type Helmet = typeof helmet;
 
-declare namespace koaHelmet {
-  type KoaHelmetContentSecurityPolicyDirectiveFunction = (
-    req?: Context["req"],
-    res?: Context["res"],
-  ) => string;
+type KoaHelmet = {
+  [HelmetMiddleware in keyof Helmet]: (
+    ...options: Parameters<Helmet[HelmetMiddleware]>
+  ) => Middleware;
+} & ((options?: HelmetOptions) => Middleware);
 
-  type KoaHelmetCspDirectiveValue =
-    | string
-    | KoaHelmetContentSecurityPolicyDirectiveFunction;
-
-  interface KoaHelmetContentSecurityPolicyDirectives {
-    baseUri?: KoaHelmetCspDirectiveValue[];
-    childSrc?: KoaHelmetCspDirectiveValue[];
-    connectSrc?: KoaHelmetCspDirectiveValue[];
-    defaultSrc?: KoaHelmetCspDirectiveValue[];
-    fontSrc?: KoaHelmetCspDirectiveValue[];
-    formAction?: KoaHelmetCspDirectiveValue[];
-    frameAncestors?: KoaHelmetCspDirectiveValue[];
-    frameSrc?: KoaHelmetCspDirectiveValue[];
-    imgSrc?: KoaHelmetCspDirectiveValue[];
-    mediaSrc?: KoaHelmetCspDirectiveValue[];
-    objectSrc?: KoaHelmetCspDirectiveValue[];
-    pluginTypes?: KoaHelmetCspDirectiveValue[];
-    prefetchSrc?: KoaHelmetCspDirectiveValue[];
-    reportTo?: string;
-    reportUri?: string;
-    sandbox?: KoaHelmetCspDirectiveValue[];
-    scriptSrc?: KoaHelmetCspDirectiveValue[];
-    scriptSrcAttr?: KoaHelmetCspDirectiveValue[];
-    scriptSrcElem?: KoaHelmetCspDirectiveValue[];
-    styleSrc?: KoaHelmetCspDirectiveValue[];
-    styleSrcAttr?: KoaHelmetCspDirectiveValue[];
-    styleSrcElem?: KoaHelmetCspDirectiveValue[];
-    workerSrc?: KoaHelmetCspDirectiveValue[];
-  }
-
-  interface KoaHelmetContentSecurityPolicyConfiguration {
-    reportOnly?: boolean;
-    useDefaults?: boolean;
-    directives?: KoaHelmetContentSecurityPolicyDirectives;
-  }
-
-  interface KoaHelmet {
-    (options?: HelmetOptions): Middleware;
-    contentSecurityPolicy(
-      options?: KoaHelmetContentSecurityPolicyConfiguration,
-    ): Middleware;
-    crossOriginEmbedderPolicy(
-      options?: HelmetOptions["crossOriginEmbedderPolicy"],
-    ): Middleware;
-    crossOriginOpenerPolicy(
-      options?: HelmetOptions["crossOriginOpenerPolicy"],
-    ): Middleware;
-    crossOriginResourcePolicy(
-      options?: HelmetOptions["crossOriginResourcePolicy"],
-    ): Middleware;
-    dnsPrefetchControl(
-      options?: HelmetOptions["dnsPrefetchControl"],
-    ): Middleware;
-    expectCt(options?: HelmetOptions["expectCt"]): Middleware;
-    frameguard(options?: HelmetOptions["frameguard"]): Middleware;
-    hidePoweredBy(options?: HelmetOptions["hidePoweredBy"]): Middleware;
-    hsts(options?: HelmetOptions["hsts"]): Middleware;
-    ieNoOpen(options?: HelmetOptions["ieNoOpen"]): Middleware;
-    noSniff(options?: HelmetOptions["noSniff"]): Middleware;
-    permittedCrossDomainPolicies(
-      options?: HelmetOptions["permittedCrossDomainPolicies"],
-    ): Middleware;
-    referrerPolicy(options?: HelmetOptions["referrerPolicy"]): Middleware;
-    xssFilter(options?: HelmetOptions["xssFilter"]): Middleware;
-  }
-}
-
-declare const koaHelmet: koaHelmet.KoaHelmet;
-export = koaHelmet;
+const koaHelmet: KoaHelmet;
+export default koaHelmet;

--- a/test/koa-helmet.spec.ts
+++ b/test/koa-helmet.spec.ts
@@ -54,11 +54,7 @@ test("it works with the default helmet call", async () => {
 
 test("it sets individual headers properly", async () => {
   const app = new Koa();
-  app.use(
-    helmet.hsts({
-      force: true,
-    }),
-  );
+  app.use(helmet.hsts());
   app.use(helmet.contentSecurityPolicy());
   app.use(helmet.crossOriginEmbedderPolicy());
   app.use(helmet.crossOriginOpenerPolicy());
@@ -71,7 +67,7 @@ test("it sets individual headers properly", async () => {
   app.use(helmet.ieNoOpen());
   app.use(helmet.referrerPolicy());
   app.use(helmet.xssFilter());
-  app.use(helmet.frameguard("deny"));
+  app.use(helmet.frameguard({ action: "deny" }));
   app.use(helmet.noSniff());
   app.use(helmet.permittedCrossDomainPolicies());
 
@@ -110,7 +106,7 @@ test("it sets individual headers properly", async () => {
     .expect("Strict-Transport-Security", "max-age=15552000; includeSubDomains")
 
     // frameguard
-    .expect("X-Frame-Options", "SAMEORIGIN")
+    .expect("X-Frame-Options", "DENY")
 
     // noSniff
     .expect("X-Content-Type-Options", "nosniff")


### PR DESCRIPTION
With latest release 7.1.0, I had to install helmet as a dependency. This produced typescript errors (with all version of Helmet I tried):

https://github.com/venables/koa-helmet/blob/884c4be4c08d0ed733c149072821426e57695d63/koa-helmet.d.ts#L11
gives 
```
node_modules/koa-helmet/koa-helmet.d.ts:11:22 - error TS2503: Cannot find namespace 'helmet'.

11 type HelmetOptions = helmet.HelmetOptions;
                        ~~~~~~
```

This is fixed easily enough by importing `HelmetOptions` directly instead.

But then we get another error:

```
node_modules/koa-helmet/koa-helmet.d.ts:70:38 - error TS2339: Property 'expectCt' does not exist on type 'HelmetOptions'.

70     expectCt(options?: HelmetOptions['expectCt']): Middleware;
```

That's happening because helmet removes `expectCt` and as a result this isn't available anymore. Helmet folks suggest to use the [expect-ct](https://www.npmjs.com/package/expect-ct) package if needed, but I'm reluctant to add this as another peer-dependency if most users of koa-helmet don't need it. 

So instead I'm using a mapped type to construct koa-helmet's default export. This should adapt koa-helmet's type with whatever helmet version a project uses.

I'm also using the JS module syntax instead of the common module syntax.

I also had to fix new typescript issues in the test file that were surfaced after this change, which proves that the change is beneficial.
This is probably a breaking change and will need a major update, but given 7.1.0 should have been a major update too, I'd say it's OK.

Please tell me what you think!